### PR TITLE
Added pangraph as a hackage dependency, bumped lts to 11.3

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,19 +1,7 @@
-resolver: lts-9.10
-
+flags: {}
+extra-package-dbs: []
 packages:
 - .
-- location:
-    git: https://github.com/tuura/pangraph.git
-    commit: 4df97a9df92bbf2dff9c0a89512d4f3d7d7d361a
-  extra-dep: true
-# Dependency packages to be pulled from upstream that are not in the resolver
-# (e.g., acme-missiles-0.3)
-extra-deps: [
-pangraph-0.0.1
-]
-
-# Override default flag values for local packages and extra-deps
-flags: {}
-
-# Extra package databases containing global packages
-extra-package-dbs: []
+extra-deps:
+- pangraph-0.1.1.5
+resolver: lts-11.3


### PR DESCRIPTION
Formerly pangraph is included from the repo directly however this is not necessary anymore.